### PR TITLE
Add CPU fallback to GPU PyTorch example

### DIFF
--- a/HPC_examples/python_scripts/gpu_pytorch_example.py
+++ b/HPC_examples/python_scripts/gpu_pytorch_example.py
@@ -10,33 +10,33 @@ logging.basicConfig(
 )
 
 def main():
-    logging.info("PyTorch GPU job started.")
+    logging.info("PyTorch job started.")
     logging.info(f"PyTorch version: {torch.__version__}")
     
     # Check if CUDA is available
-    if not torch.cuda.is_available():
-        logging.error("CUDA is not available. Exiting.")
-        return
-    
-    num_gpus = torch.cuda.device_count()
-    logging.info(f"Number of CUDA devices available: {num_gpus}")
+    if torch.cuda.is_available():
+        num_gpus = torch.cuda.device_count()
+        logging.info(f"Number of CUDA devices available: {num_gpus}")
 
-    for i in range(num_gpus):
-        device_name = torch.cuda.get_device_name(i)
-        logging.info(f"GPU {i}: {device_name}")
+        for i in range(num_gpus):
+            device_name = torch.cuda.get_device_name(i)
+            logging.info(f"GPU {i}: {device_name}")
 
-    device = torch.device("cuda:0")
+        device = torch.device("cuda:0")
+        logging.info(f"Using device: {device} ({torch.cuda.get_device_name(device)})")
+    else:
+        logging.warning("CUDA is not available. Using CPU instead.")
+        device = torch.device("cpu")
+        logging.info(f"Using device: {device}")
 
-    logging.info(f"Using device: {device} ({torch.cuda.get_device_name(device)})")
-
-    # Dummy workload to simulate GPU usage
-    logging.info("Running dummy tensor operation on GPU...")
+    # Dummy workload to simulate tensor operations
+    logging.info("Running dummy tensor operation...")
     x = torch.rand((5000, 5000), device=device)
     y = torch.mm(x, x)
     result = y.sum().item()
 
     logging.info(f"Computation complete. Result: {result:.4f}")
-    logging.info("PyTorch GPU job finished.")
+    logging.info("PyTorch job finished.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Description
This PR modifies the `gpu_pytorch_example.py` script to add CPU fallback functionality when CUDA is not available. This enhancement allows the script to run in environments without GPU access, making it more versatile for testing and development.

## Changes Made
- Modified the `gpu_pytorch_example.py` script to check for CUDA availability and use CPU as a fallback
- Restructured the code to maintain the same functionality when a GPU is available
- Updated logging messages to reflect the device being used (GPU or CPU)

## Testing
- Tested the modified script in an environment without CUDA
- Verified that the script runs successfully on CPU and completes the tensor operations
- Confirmed that the script logs appropriate messages about device usage

## Benefits
- Improved usability in environments without GPU access
- Maintains original functionality when GPU is available
- Makes the example more accessible for users who want to test the code without GPU resources

This change is backward compatible and does not affect the behavior when running on systems with GPU access.

@marcohernandezusal can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f4995956a3b3428a9edd32f598f050bd)